### PR TITLE
Update dbup reference to 4.5.0 so we can override the name on SqlScript

### DIFF
--- a/source/octopus.dbup.sqlserver.csproj
+++ b/source/octopus.dbup.sqlserver.csproj
@@ -11,7 +11,7 @@
     </PropertyGroup>
 
     <ItemGroup>
-      <PackageReference Include="dbup-core" Version="4.3.0" />
+      <PackageReference Include="dbup-core" Version="4.5.0" />
       <PackageReference Include="Microsoft.Azure.Services.AppAuthentication" Version="1.3.1" />
       <PackageReference Include="Microsoft.Data.SqlClient" Version="1.1.0" />
     </ItemGroup>


### PR DESCRIPTION
Updating the package reference so we can get this change: https://github.com/DbUp/DbUp/pull/540

Octopus Server needs to override the script name from a C# script.

https://trello.com/c/nwHg46cr/130-support-export-set-upgrades