### PR TITLE
Patch SqlClient vulnerability

### DIFF
--- a/source/octopus.dbup.sqlserver.csproj
+++ b/source/octopus.dbup.sqlserver.csproj
@@ -13,7 +13,7 @@
     <ItemGroup>
       <PackageReference Include="dbup-core" Version="4.5.0" />
       <PackageReference Include="Microsoft.Azure.Services.AppAuthentication" Version="1.3.1" />
-      <PackageReference Include="Microsoft.Data.SqlClient" Version="1.1.0" />
+      <PackageReference Include="Microsoft.Data.SqlClient" Version="1.1.4" />
     </ItemGroup>
 
 </Project>


### PR DESCRIPTION
Microsoft disclosed a [moderate vulnerability](https://github.com/advisories/GHSA-8g2p-5pqh-5jmc) on their SqlClient libraries affecting a few versions.

This PR updates such library to a patched version.

https://octopusdeploy.slack.com/archives/C04AD1H7LLC/p1668387022805969

[sc-30875]