### PR TITLE
Add ability to manually run GHA

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -14,6 +14,9 @@ on:
     # Daily 5am australian/brisbane time
     - cron: "0 19 * * *"
 
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
+
 jobs:
   build:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Background

We currently do not have a way to manually run the git hub action. This PR adds the command to the main workflow to allow this.

## Results

The workflow should now be able to be run manually

## Notes

<!-- Anything else? -->