### PR TITLE
Remove AppAuthentication NuGet package

### DIFF
--- a/source/octopus.dbup.sqlserver.csproj
+++ b/source/octopus.dbup.sqlserver.csproj
@@ -12,7 +12,6 @@
 
     <ItemGroup>
       <PackageReference Include="dbup-core" Version="5.0.8" />
-      <PackageReference Include="Microsoft.Azure.Services.AppAuthentication" Version="1.3.1" />
       <PackageReference Include="Microsoft.Data.SqlClient" Version="1.1.4" />
     </ItemGroup>
 


### PR DESCRIPTION
This PR removes the `Microsoft.Azure.Services.AppAuthentication` NuGet package from the dependencies as it is unused.

[sc-37403]