### PR TITLE
Connect to Octopus with OIDC, timestamp nightly build numbers

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -31,7 +31,7 @@ jobs:
       - name: Add nightly suffix if nightly
         if: github.event_name == 'schedule'
         run: |
-          version="${{ env.VERSION }}-nightly"
+          version="${{ env.VERSION }}-nightly-$(date +'%Y%m%d%H%M%S')"
           echo "Current Version: ${version}"
           echo "VERSION=${version}" >> "$GITHUB_ENV"
 
@@ -55,11 +55,13 @@ jobs:
         run: dotnet publish -c Release /p:Version=${{ env.VERSION }} ./source
 
       - name: Push to Octopus 🐙
+        if: (! contains(github.ref, '/merge')) && (! contains(github.ref, '/dependabot/')) && (! contains(github.ref, 'prettybot/'))
         uses: OctopusDeploy/push-package-action@v3
         with:
           packages: ./source/bin/Release/octopus.dbup.sqlserver.${{ env.VERSION }}.nupkg
 
       - name: Create a release in Octopus Deploy 🐙
+        if: (! contains(github.ref, '/merge')) && (! contains(github.ref, '/dependabot/')) && (! contains(github.ref, 'prettybot/'))
         uses: OctopusDeploy/create-release-action@v3
         with:
           project: "Octopus.Dbup.SqlServer"

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -23,8 +23,6 @@ jobs:
     env:
       ACTIONS_ALLOW_UNSECURE_COMMANDS: true # to allow setting version env var
       VERSION: "1.1.${{ github.run_number }}"
-      OCTOPUS_API_KEY: "${{ secrets.DEPLOY_API_KEY }}"
-      OCTOPUS_URL: "${{ secrets.DEPLOY_URL }}"
       OCTOPUS_SPACE: "Core Platform"
       
     steps:
@@ -53,6 +51,13 @@ jobs:
       # GeneratePackageOnBuild is specified in the csproj, so this will produce a nupkg
       - name: Pack
         run: dotnet publish -c Release /p:Version=${{ env.VERSION }} ./source
+
+      - name: Login to Octopus Deploy 🐙
+        if: (! contains(github.ref, '/merge')) && (! contains(github.ref, '/dependabot/')) && (! contains(github.ref, 'prettybot/'))
+        uses: OctopusDeploy/login@v1
+        with: 
+          server: https://deploy.octopus.app
+          service_account_id: 2552cea7-8cee-454e-a56b-e20e373e9c1f
 
       - name: Push to Octopus 🐙
         if: (! contains(github.ref, '/merge')) && (! contains(github.ref, '/dependabot/')) && (! contains(github.ref, 'prettybot/'))

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -20,6 +20,9 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
+    permissions:
+      id-token: write # Required to obtain the ID token from GitHub Actions
+      contents: read # Required to check out code
     env:
       ACTIONS_ALLOW_UNSECURE_COMMANDS: true # to allow setting version env var
       VERSION: "1.1.${{ github.run_number }}"


### PR DESCRIPTION
## Background

Our API keys periodically expire, breaking things.

## Results

Octopus now supports OIDC for github actions, with wildcards on permitted branches, enabling us to authenticate via OIDC and remove the need for API keys entirely.
You can see it in action on this branch build: https://github.com/OctopusDeploy/Octopus.dbup.SqlServer/actions/runs/7632927662/job/20794128644

Also adds a timestamp to nightly builds to follow common practice from our other repos

## Notes

<!-- Anything else? -->